### PR TITLE
feat: add rate limiting with delay parameter

### DIFF
--- a/scraper/scrapers/__init__.py
+++ b/scraper/scrapers/__init__.py
@@ -16,6 +16,7 @@ Extra directive keys handled here:
   validate: {...}     — per-field validation rules
 """
 
+import time
 import yaml
 from pathlib import Path
 
@@ -130,13 +131,17 @@ async def _dispatch(dados: dict, stats: ScrapeStats, directive_name: str) -> lis
     # ── Multi-site ────────────────────────────────────────────────────────────
     if has_sites:
         results = []
-        for url in dados["sites"]:
+        delay = dados.get("delay", 0)
+        for idx, url in enumerate(dados["sites"]):
             site_dados = {**dados, "site": url}
             site_dados.pop("sites", None)
             if use == "beautifulsoup":
                 results.append(bs4_scraper.scrape(site_dados))
             else:
                 results.append(await playwright_scraper.scrape(site_dados, directive_name))
+            # Apply delay between multi-site requests (skip after last)
+            if delay > 0 and idx < len(dados["sites"]) - 1:
+                time.sleep(delay)
         stats.urls_scraped = len(results)
         return results
 

--- a/scraper/scrapers/bs4_scraper.py
+++ b/scraper/scrapers/bs4_scraper.py
@@ -14,6 +14,7 @@ Directive options consumed here:
   proxy: "http://..."          — proxy URL
   retries: 3                   — retry count on HTTP error (default 3)
   timeout: 15                  — request timeout in seconds (default 15)
+  delay: 1.0                   — delay in seconds between requests (default 0, for rate limiting)
   cache:
     ttl: 3600                  — cache TTL in seconds (0 = disabled)
 """
@@ -45,8 +46,28 @@ def fetch_html(
     cookies: dict | None = None,
     proxy: str | None = None,
     cache_ttl: int = 0,
+    delay: float = 0,
 ) -> str:
-    """Fetch URL and return HTML string. Caches if cache_ttl > 0."""
+    """Fetch URL and return HTML string. Caches if cache_ttl > 0.
+    
+    Args:
+        url: Target URL to fetch
+        retries: Number of retry attempts on failure (default 3)
+        backoff: Initial backoff time in seconds (default 2.0)
+        timeout: Request timeout in seconds (default 15)
+        headers: Additional HTTP headers to include
+        cookies: Cookie dictionary to send with request
+        proxy: Proxy URL (http or https)
+        cache_ttl: Cache TTL in seconds, 0 disables caching (default 0)
+        delay: Delay in seconds before making request (default 0, for rate limiting)
+    
+    Returns:
+        HTML content as string
+    """
+    # Apply rate limiting delay before making the request
+    if delay > 0:
+        time.sleep(delay)
+    
     cached = _cache.get(url, cache_ttl)
     if cached is not None:
         return cached
@@ -149,6 +170,7 @@ def scrape(dados: dict) -> dict:
         cookies=dados.get("cookies"),
         proxy=dados.get("proxy"),
         cache_ttl=cache_ttl,
+        delay=dados.get("delay", 0),
     )
     soup = BeautifulSoup(html, "html.parser")
     return parse_page(soup, dados["site"], dados["scrape"])

--- a/scraper/scrapers/paginator.py
+++ b/scraper/scrapers/paginator.py
@@ -34,6 +34,7 @@ def paginate(dados: dict) -> list[dict]:
         cookies=dados.get("cookies"),
         proxy=dados.get("proxy"),
         cache_ttl=cache_ttl,
+        delay=dados.get("delay", 0),
     )
 
     current_url = dados["site"]

--- a/scraper/scrapers/playwright_scraper.py
+++ b/scraper/scrapers/playwright_scraper.py
@@ -8,10 +8,13 @@ Directive options consumed here:
   cookies: []                  — list of cookie dicts: {name, value, domain}
   proxy: "http://..."          — proxy URL
   timeout: 30000               — page load timeout in ms (default 30000)
+  delay: 1.0                   — delay in seconds between requests (default 0, for rate limiting)
   wait_for: 'selector'         — wait for this selector before scraping
   screenshot: true             — save screenshot to output/<directive>_<ts>.png
 """
 
+import asyncio
+import time
 from datetime import datetime
 from pathlib import Path
 
@@ -22,6 +25,11 @@ from scraper.config import OUTPUT_DIR
 
 async def scrape(dados: dict, directive_name: str = "") -> dict:
     """Scrape a single URL using Playwright (headless Chromium)."""
+    # Apply rate limiting delay before making the request
+    delay = dados.get("delay", 0)
+    if delay > 0:
+        await asyncio.sleep(delay)
+    
     proxy_cfg = None
     if proxy := dados.get("proxy"):
         proxy_cfg = {"server": proxy}

--- a/scraper/scrapers/spider.py
+++ b/scraper/scrapers/spider.py
@@ -40,6 +40,7 @@ class Spider:
             cookies=dados.get("cookies"),
             proxy=dados.get("proxy"),
             cache_ttl=cache_cfg.get("ttl", 0) if isinstance(cache_cfg, dict) else 0,
+            delay=dados.get("delay", 0),
         )
 
     def run(self) -> list[dict]:


### PR DESCRIPTION
This PR adds a new `delay` parameter to implement rate limiting in the scraper.

Changes:
- Add delay parameter to bs4_scraper fetch_html for rate limiting
- Add delay parameter to playwright_scraper for rate limiting
- Update paginator and spider to pass delay parameter
- Update multi-site scraping to apply delay between requests
- Document new delay option in docstrings