### PR TITLE
docs: add slugify, truncate and normalize_whitespace to README transform table

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,9 @@ notify:
 | `prepend` / `append` | `"str"` | Add text before/after |
 | `remove_tags` | — | Strip HTML tags |
 | `template` | `"prefix {value}"` | String template with `{value}` or `{other_field}` |
+| `slugify` | — | Convert text to a URL-friendly slug (`Hello World` → `hello-world`) |
+| `truncate` | `N` | Truncate to N characters without breaking words, appends `...` |
+| `normalize_whitespace` | — | Collapse multiple spaces/tabs into a single space and strip |
 
 ### Available validation rules
 


### PR DESCRIPTION
Closes #20

Added the three missing transforms (slugify, truncate, normalize_whitespace) 
to the Available transforms table in README.md with arguments and descriptions.