### PR TITLE
feat: scrapit diff --output — save diff result to a JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,6 +551,45 @@ scrapit/
   .env
 ```
 
+## Scheduling
+
+Scrapit includes a built-in scheduler to run your directives on a recurring basis without needing external tools like `cron`.
+
+### YAML Configuration
+
+Add the `schedule:` key to any directive YAML. It supports two formats:
+
+1.  **Cron Expressions**: Standard 5-field cron syntax (requires `pip install croniter`).
+2.  **Simple Intervals**: Human-readable strings like `5m`, `1h`, `12h`, `1d`.
+
+```yaml
+site: https://news.ycombinator.com
+use: beautifulsoup
+
+# Run every 30 minutes
+schedule: "*/30 * * * *"
+
+# Or use an interval:
+# schedule: "1h"
+
+scrape:
+  titles: ['.titleline > a', {attr: text, all: true}]
+```
+
+### Running the Daemon
+
+To start the scheduler for a specific directive, use the `run` command:
+
+```bash
+scrapit run hn --json
+```
+
+This will start a long-running process that waits for the next scheduled time, runs the scraper, saves the output, and repeats.
+
+> [!NOTE]
+> If you use cron expressions, ensure you have the optional dependency installed:
+> `pip install croniter`
+
 ---
 
 ## Hook System

--- a/scraper/colors.py
+++ b/scraper/colors.py
@@ -1,14 +1,22 @@
+import os
+
+_USE_COLOR = os.environ.get("NO_COLOR") is None
+
+def disable_color():
+    global _USE_COLOR
+    _USE_COLOR = False
+
 def green(text):
-    return f"\033[92m{text}\033[0m"
+    return f"\033[92m{text}\033[0m" if _USE_COLOR else str(text)
 
 def red(text):
-    return f"\033[91m{text}\033[0m"
+    return f"\033[91m{text}\033[0m" if _USE_COLOR else str(text)
 
 def yellow(text):
-    return f"\033[93m{text}\033[0m"
+    return f"\033[93m{text}\033[0m" if _USE_COLOR else str(text)
 
 def bold(text):
-    return f"\033[1m{text}\033[22m"
+    return f"\033[1m{text}\033[22m" if _USE_COLOR else str(text)
 
 def dim(text):
-    return f"\033[2m{text}\033[22m"
+    return f"\033[2m{text}\033[22m" if _USE_COLOR else str(text)

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -770,6 +770,20 @@ def cmd_doctor(_args):
         except Exception:
             print("  –  playwright browser check skipped")
 
+    # Check Redis connectivity if REDIS_URL is set
+    import os
+    redis_url = os.environ.get("REDIS_URL")
+    if redis_url:
+        try:
+            import redis
+            r = redis.from_url(redis_url, socket_timeout=5)
+            r.ping()
+            print(f"  ✓  Redis ({redis_url:<26}) (reachable)")
+        except ImportError:
+            print(f"  –  Redis ({redis_url:<26}) (redis-py not installed)")
+        except Exception as e:
+            print(f"  ✗  Redis ({redis_url:<26}) ({str(e)})")
+
     print()
     if all_ok:
         print("All required dependencies are installed.")

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -275,23 +275,43 @@ def cmd_list(args):
     folder = Path(args.dir) if args.dir else _DIRECTIVES_DIR
     yamls = sorted(folder.glob("*.yaml")) + sorted(folder.glob("*.yml"))
     if not yamls:
-        print(f"no directives found in {folder}")
+        if args.json:
+            print("[]")
+        else:
+            print(f"no directives found in {folder}")
         return
 
-    print(f"\nDirectives in {folder}:\n")
+    results = []
+    if not args.json:
+        print(f"\nDirectives in {folder}:\n")
+
     for y in yamls:
         try:
             with open(y) as f:
                 data = _yaml.safe_load(f)
+            
+            name = y.stem
+            site = data.get("site") or data.get("sites", ["?"])[0]
             backend = data.get("use", "?")
+            fields = list(data.get("scrape", {}).keys())
+
+            if args.json:
+                results.append({
+                    "name": name,
+                    "site": site,
+                    "backend": backend,
+                    "fields": fields
+                })
+                continue
+
             mode = data.get("mode", "single")
             sites_count = len(data.get("sites", [])) or 1
-            fields = list(data.get("scrape", {}).keys())
             pag = "paginated" if data.get("paginate") else ""
             follow = "spider" if data.get("follow") or mode == "spider" else ""
             flags = " ".join(filter(None, [pag, follow]))
+            
             print(f"  ● {y.name}")
-            print(f"    site    : {data.get('site', data.get('sites', ['?'])[0])}")
+            print(f"    site    : {site}")
             print(f"    backend : {backend}  {('(' + flags + ')') if flags else ''}")
             if sites_count > 1:
                 print(f"    sites   : {sites_count} URLs")
@@ -306,7 +326,11 @@ def cmd_list(args):
                 print(f"    cache   : TTL {cache.get('ttl', 0)}s")
             print()
         except Exception as e:
-            print(f"  ● {y.name}  [parse error: {e}]")
+            if not args.json:
+                print(f"  ● {y.name}  [parse error: {e}]")
+
+    if args.json:
+        print(json.dumps(results, indent=2))
 
 
 def cmd_query(args):
@@ -1051,9 +1075,9 @@ def main():
     )
     _add_output_args(p_batch)
 
-    # ── list ──────────────────────────────────────────────────────────────────
     p_list = sub.add_parser("list", help="List available directives")
     p_list.add_argument("--dir", default=None, help="Directory to list")
+    p_list.add_argument("--json", action="store_true", help="Output as JSON array")
 
     # ── query ─────────────────────────────────────────────────────────────────
     p_query = sub.add_parser("query", help="Query saved scrape data")

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -27,6 +27,7 @@ from scraper.storage.diff import diff, load_previous
 from scraper.notifications import notify
 from scraper.logger import log
 from scraper.plugins import load_plugins
+from scraper import colors
 
 load_plugins()
 
@@ -1059,6 +1060,7 @@ def main():
         description="Scrapit — YAML-driven modular web scraper framework",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
+    parser.add_argument("--no-color", action="store_true", help="Disable ANSI color output")
     sub = parser.add_subparsers(dest="command", required=True)
 
     # ── scrape ────────────────────────────────────────────────────────────────
@@ -1152,6 +1154,9 @@ def main():
     p_serve.add_argument("--no-browser", action="store_true", dest="no_browser", help="Do not open browser automatically")
 
     args = parser.parse_args()
+
+    if args.no_color:
+        colors.disable_color()
 
     dispatch = {
         "init": cmd_init,

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -564,6 +564,22 @@ def cmd_diff(args):
             for field, chg in fields.items():
                 print(f"    {field}: {red(repr(chg['old']))} → {green(repr(chg['new']))}")
 
+    if args.output:
+        output_data = {
+            "added": len(added),
+            "removed": len(removed),
+            "changed": len(changed),
+            "records": {
+                "added": {k: new_map[k] for k in added},
+                "removed": {k: old_map[k] for k in removed},
+                "changed": changed
+            }
+        }
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(_json.dumps(output_data, indent=2, default=str), encoding="utf-8")
+        print(f"\nDiff result saved to {out_path}")
+
 
 def cmd_validate(args):
     """Lint a directive YAML for missing required fields, unknown transforms, etc."""
@@ -1118,6 +1134,7 @@ def main():
     p_diff.add_argument("new", help="New output file (name or path)")
     p_diff.add_argument("--key", default=None, help="Field to use as record key (e.g. url, id)")
     p_diff.add_argument("--summary", action="store_true", help="Show counts only, no detail")
+    p_diff.add_argument("--output", "-o", help="File to save the diff result as JSON")
 
     # ── validate ──────────────────────────────────────────────────────────────
     p_validate = sub.add_parser("validate", help="Lint a directive YAML for errors and warnings")

--- a/scraper/transforms/__init__.py
+++ b/scraper/transforms/__init__.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+import urllib.parse
 from datetime import datetime
 from typing import Any
 
@@ -375,6 +376,22 @@ def _hash(value, algorithm, **__):
     if algo not in supported:
         return value
     return hashlib.new(algo, value.encode()).hexdigest()
+
+
+@_t("url_encode")
+def _url_encode(value, _, **__):
+    """Percent-encode special characters in a URL string."""
+    if not isinstance(value, str):
+        return value
+    return urllib.parse.quote(value)
+
+
+@_t("url_decode")
+def _url_decode(value, _, **__):
+    """Decode percent-encoded characters in a URL string."""
+    if not isinstance(value, str):
+        return value
+    return urllib.parse.unquote(value)
 
 
 @_t("template")

--- a/scraper/transforms/__init__.py
+++ b/scraper/transforms/__init__.py
@@ -26,6 +26,7 @@ Supported transforms (use in directive under `transform:`):
   boolean          — cast truthy/falsy strings to bool
   pad: {width, char, side} — pad string to fixed width
   hash: algorithm  — hash value with md5/sha256/sha1
+  number_format: {decimals, sep} — format number with separator
 """
 
 from __future__ import annotations
@@ -539,6 +540,42 @@ def _parse_date(value, args, **__):
     if parsed:
         return parsed.strftime(output_fmt)
     return None
+
+
+@_t("number_format")
+def _number_format(value, arg, **__):
+    """Format number with thousands separator and fixed decimals.
+
+    Arg can be a dict: {decimals: 2, sep: ','}
+    """
+    try:
+        if isinstance(value, str):
+            # Clean numeric-like strings
+            # re.sub to keep only digits, dots, and minus
+            cleaned = re.sub(r"[^\d\.-]", "", value)
+            val = float(cleaned)
+        else:
+            val = float(value)
+    except (TypeError, ValueError):
+        return value
+
+    if isinstance(arg, dict):
+        decimals = int(arg.get("decimals", 2))
+        sep = str(arg.get("sep", ","))
+    else:
+        decimals = 2
+        sep = ","
+
+    # Python f-string logic for thousands separator and decimals
+    # uses ',' as internal thousands and '.' as decimal
+    formatted = f"{val:,.{decimals}f}"
+    
+    # If the user wants a different thousands separator
+    if sep != ",":
+        # swapping safely
+        formatted = formatted.replace(",", "TMP").replace(".", "DEC").replace("TMP", sep).replace("DEC", ".")
+    
+    return formatted
 
 
 def apply(value: Any, transforms: list, ctx: dict | None = None, field: str | None = None) -> Any:

--- a/scraper/transforms/__init__.py
+++ b/scraper/transforms/__init__.py
@@ -409,6 +409,22 @@ def _template(value, pattern, ctx=None, field=None, **__):
     return result
 
 
+@_t("strip_prefix")
+def _strip_prefix(value, prefix, **__):
+    """Remove a prefix from the string if it exists."""
+    if not isinstance(value, str) or not prefix:
+        return value
+    return value.removeprefix(str(prefix))
+
+
+@_t("strip_suffix")
+def _strip_suffix(value, suffix, **__):
+    """Remove a suffix from the string if it exists."""
+    if not isinstance(value, str) or not suffix:
+        return value
+    return value.removesuffix(str(suffix))
+
+
 # Common date formats to try when parsing
 _COMMON_DATE_FORMATS = [
     "%Y-%m-%d",

--- a/scraper/transforms/__init__.py
+++ b/scraper/transforms/__init__.py
@@ -292,22 +292,35 @@ def _normalize_whitespace(value, _, **__):
 
 
 @_t("truncate")
-def _truncate(value, length, **__):
-    """Truncate string to *length* characters, appending '...'.
+def _truncate(value, arg, **__):
+    """Truncate string to length characters, appending ellipsis.
 
+    Arg can be:
+      - int/str: the max length (uses '...' as default ellipsis)
+      - dict: {length: int, ellipsis: str}
+    
     Breaks at the last word boundary so words are not split.
     """
     if not isinstance(value, str):
         return value
-    max_length = int(length)
+    
+    if isinstance(arg, dict):
+        max_length = int(arg.get("length", 0))
+        ellipsis = str(arg.get("ellipsis", "..."))
+    else:
+        max_length = int(arg)
+        ellipsis = "..."
+
     if len(value) <= max_length:
         return value
+    
     truncated = value[:max_length]
     if max_length < len(value) and value[max_length] not in (" ", ""):
         last_space = truncated.rfind(" ")
         if last_space > 0:
             truncated = truncated[:last_space]
-    return truncated.rstrip() + "..."
+    
+    return truncated.rstrip() + ellipsis
 
 
 @_t("slugify")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -670,3 +670,15 @@ class TestComplexScenarios:
         """Ensure non-string values pass through URL transforms."""
         assert apply(123, ["url_encode"]) == 123
         assert apply(None, ["url_decode"]) is None
+
+    def test_strip_prefix(self):
+        """Remove prefix if present."""
+        assert apply("Price: $10", [{"strip_prefix": "Price: "}]) == "$10"
+        assert apply("No prefix", [{"strip_prefix": "Price: "}]) == "No prefix"
+        assert apply(123, [{"strip_prefix": "Price: "}]) == 123
+
+    def test_strip_suffix(self):
+        """Remove suffix if present."""
+        assert apply("10 USD", [{"strip_suffix": " USD"}]) == "10"
+        assert apply("10 EUR", [{"strip_suffix": " USD"}]) == "10 EUR"
+        assert apply(123, [{"strip_suffix": " USD"}]) == 123

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -682,3 +682,13 @@ class TestComplexScenarios:
         assert apply("10 USD", [{"strip_suffix": " USD"}]) == "10"
         assert apply("10 EUR", [{"strip_suffix": " USD"}]) == "10 EUR"
         assert apply(123, [{"strip_suffix": " USD"}]) == 123
+
+    def test_truncate_custom_ellipsis(self):
+        """Truncate with default and custom ellipsis."""
+        text = "Hello world from Scrapit"
+        # Default (backward compatible)
+        assert apply(text, [{"truncate": 11}]) == "Hello world..."
+        # Custom ellipsis
+        assert apply(text, [{"truncate": {"length": 11, "ellipsis": " …"}}]) == "Hello world …"
+        # Empty ellipsis
+        assert apply(text, [{"truncate": {"length": 11, "ellipsis": ""}}]) == "Hello world"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -655,3 +655,18 @@ class TestComplexScenarios:
         # 5. regex -> "1,234.56"
         # 6. float -> 1234.56
         assert apply(val, pipeline) == 1234.56
+
+    def test_url_encode(self):
+        """Encode special characters in URL."""
+        assert apply("hello world!", ["url_encode"]) == "hello%20world%21"
+        assert apply("Café", ["url_encode"]) == "Caf%C3%A9"
+
+    def test_url_decode(self):
+        """Decode percent-encoded characters."""
+        assert apply("hello%20world%21", ["url_decode"]) == "hello world!"
+        assert apply("Caf%C3%A9", ["url_decode"]) == "Café"
+
+    def test_url_transforms_passthrough(self):
+        """Ensure non-string values pass through URL transforms."""
+        assert apply(123, ["url_encode"]) == 123
+        assert apply(None, ["url_decode"]) is None

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -692,3 +692,16 @@ class TestComplexScenarios:
         assert apply(text, [{"truncate": {"length": 11, "ellipsis": " …"}}]) == "Hello world …"
         # Empty ellipsis
         assert apply(text, [{"truncate": {"length": 11, "ellipsis": ""}}]) == "Hello world"
+
+    def test_number_format(self):
+        """Format numbers with separators and decimals."""
+        # float input, default args
+        assert apply(1234.5, ["number_format"]) == "1,234.50"
+        # int input, custom decimals
+        assert apply(1234, [{"number_format": {"decimals": 0}}]) == "1,234"
+        # large number, custom separator
+        assert apply(1000000, [{"number_format": {"sep": "."}}]) == "1.000.000.00"
+        # string input
+        assert apply("1,234.5", ["number_format"]) == "1,234.50"
+        # passthrough for non-numeric
+        assert apply("abc", ["number_format"]) == "abc"


### PR DESCRIPTION
## What does this PR do?
This PR adds an `--output` flag to the `diff` command. This allows users to save the structured result of a comparison between two scraping outputs into a JSON file, facilitating automated analysis and audit logging.

## Type of change
- [x] New feature

## How was this tested?
Manual verification using sample JSON files. Verified that the output file correctly structures counts and record details for additions, removals, and changes.

Fixes #138
