### PR TITLE
feat: REST/JSON API scraper backend (use: rest)

### DIFF
--- a/scraper/scrapers/__init__.py
+++ b/scraper/scrapers/__init__.py
@@ -192,6 +192,9 @@ async def _dispatch(dados: dict, stats: ScrapeStats, directive_name: str, resume
             elif use == "brightdata":
                 from scraper.integrations.brightdata import scrape as bd_scrape
                 results.append(await bd_scrape(site_dados, directive_name))
+            elif use == "rest":
+                from scraper.scrapers.rest_scraper import scrape as rest_scrape
+                results.append(rest_scrape(site_dados))
             else:
                 results.append(await playwright_scraper.scrape(site_dados, directive_name))
             if delay > 0 and idx < len(dados["sites"]) - 1:
@@ -221,6 +224,9 @@ async def _dispatch(dados: dict, stats: ScrapeStats, directive_name: str, resume
     if use == "graphql":
         from scraper.scrapers.graphql_scraper import scrape as gql_scrape
         return [gql_scrape(dados)]
+    elif use == "rest":
+        from scraper.scrapers.rest_scraper import scrape as rest_scrape
+        return [rest_scrape(dados)]
     elif use in ("beautifulsoup", "bs4"):
         return [bs4_scraper.scrape(dados)]
     elif use == "httpx":

--- a/scraper/scrapers/rest_scraper.py
+++ b/scraper/scrapers/rest_scraper.py
@@ -1,0 +1,55 @@
+"""
+REST scraper backend — query JSON APIs via directives.
+
+Directive format:
+  use: rest
+  site: https://api.example.com/data
+  method: GET  # optional, default is GET
+  headers:     # optional
+    Authorization: "Bearer ${TOKEN}"
+  body:        # optional, sent as JSON for POST/PUT
+    key: val
+
+  scrape:
+    name: { path: data.user.name }
+    id:   { path: data.user.id }
+"""
+
+import requests
+from datetime import datetime
+from scraper.scrapers.graphql_scraper import _get_path
+
+
+def scrape(dados: dict) -> dict:
+    method  = str(dados.get("method", "GET")).upper()
+    headers = {"Content-Type": "application/json", **(dados.get("headers") or {})}
+    body    = dados.get("body")
+    timeout = dados.get("timeout", 15)
+    site    = dados["site"]
+
+    resp = requests.request(
+        method=method,
+        url=site,
+        json=body if body and method in ("POST", "PUT", "PATCH") else None,
+        headers=headers,
+        timeout=timeout,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+
+    result = {}
+    for key, spec in dados.get("scrape", {}).items():
+        if isinstance(spec, dict):
+            path = spec.get("path", key)
+        elif isinstance(spec, list) and spec:
+            path = spec[0] if isinstance(spec[0], str) else key
+        else:
+            path = key
+        
+        # Support 'all' if the dot path points to a list? 
+        # For now, let's stick to the basic _get_path behavior.
+        result[key] = _get_path(data, path)
+
+    result["url"] = site
+    result["timestamp"] = datetime.now()
+    return result


### PR DESCRIPTION
## What does this PR do?
This PR introduces a new `rest` backend, allowing users to scrape plain JSON APIs. It supports custom HTTP methods, headers, and request bodies, using dot-notation paths for field extraction.

## Type of change
- [x] New feature

## How was this tested?
Verified using a test directive targeting the GitHub API, ensuring correct extraction of nested and top-level JSON fields.

Fixes #139
