### PR TITLE
feat: S3 storage backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# pip install scrapit[s3]
+s3 = ["boto3>=1.26"]
+
 # pip install scrapit[mongo]
 mongo = ["pymongo>=4.0"]
 
@@ -93,6 +96,7 @@ all = [
   "anthropic>=0.25",
   "openai>=1.0",
   "mcp>=1.0",
+  "boto3>=1.26",
 ]
 
 # pip install scrapit[dev]

--- a/scraper/main.py
+++ b/scraper/main.py
@@ -67,7 +67,8 @@ def _resolve(path_str: str) -> Path:
 # ── Storage dispatch ──────────────────────────────────────────────────────────
 
 def _save(result: dict | list, name: str, dest: str, *, output_dir: str | None = None,
-          compact: bool = False, spreadsheet_id: str = None, credentials_path: str = None):
+          compact: bool = False, spreadsheet_id: str = None, credentials_path: str = None,
+          output_config: dict | None = None):
     items = result if isinstance(result, list) else [result]
     for item in items:
         if dest == "mongo":
@@ -84,7 +85,7 @@ def _save(result: dict | list, name: str, dest: str, *, output_dir: str | None =
         elif dest == "postgres":
             postgres_storage.save(item, name)
             print(f"→ saved {len(items)} record(s) to PostgreSQL.")
-        elif dest == "parquet":
+        elif dest in ("parquet", "s3"):
             break  # handled below (whole list at once)
         else:
             # json: save list or single dict
@@ -93,6 +94,10 @@ def _save(result: dict | list, name: str, dest: str, *, output_dir: str | None =
         from scraper.storage import parquet_file
         out = parquet_file.save(items, name, output_dir=output_dir)
         print(f"→ saved {len(items)} record(s) to: {out}")
+    elif dest == "s3":
+        from scraper.storage import s3 as s3_storage
+        out = s3_storage.save(result, name, config=output_config)
+        print(f"→ saved to S3: {out}")
     elif dest == "json":
         out = json_file.save(result, name, output_dir=output_dir, compact=compact)
         print(f"→ saved: {out}")
@@ -132,6 +137,16 @@ def _run_one(
 ):
     import yaml
     name = directive_path.stem
+
+    try:
+        with open(directive_path) as f:
+            dados = yaml.safe_load(f)
+    except Exception:
+        dados = {}
+    
+    output_cfg = dados.get("output", {})
+    if dest == "json" and "backend" in output_cfg:
+        dest = output_cfg["backend"]
 
     _stream_results = []
 
@@ -204,7 +219,8 @@ def _run_one(
 
     if not preview:
         _save(result, name, dest, output_dir=output_dir, compact=compact,
-              spreadsheet_id=spreadsheet_id, credentials_path=credentials_path)
+              spreadsheet_id=spreadsheet_id, credentials_path=credentials_path,
+              output_config=output_cfg)
         from scraper import hooks
         hooks.fire("on_save", result, dest)
     else:
@@ -1031,6 +1047,8 @@ def _dest(args) -> str:
         return "postgres"
     if getattr(args, "parquet", False):
         return "parquet"
+    if getattr(args, "s3", False):
+        return "s3"
     return "json"
 
 
@@ -1044,6 +1062,7 @@ def _add_output_args(p):
     group.add_argument("--sheets", action="store_true", help="Append to Google Sheets")
     group.add_argument("--postgres", action="store_true", help="Save to PostgreSQL")
     group.add_argument("--parquet", action="store_true", help="Save to output/<name>.parquet")
+    group.add_argument("--s3", action="store_true", help="Save to AWS S3")
     p.add_argument("--output-dir", help="Custom output directory (overrides default 'output/')")
     p.add_argument("--format", choices=["pretty", "compact"], default="pretty",
                    help="JSON output format: pretty (indented, default) or compact (minified)")

--- a/scraper/storage/s3.py
+++ b/scraper/storage/s3.py
@@ -1,0 +1,46 @@
+import json
+import os
+import sys
+
+def save(data: dict | list, name: str, config: dict | None = None) -> str:
+    """
+    Save data to AWS S3. 
+    Serializes to JSON and uploads to s3://bucket/prefix/name.json.
+    """
+    try:
+        import boto3
+    except ImportError:
+        print("error: boto3 is not installed. Install with: pip install boto3", file=sys.stderr)
+        sys.exit(1)
+
+    if config is None:
+        config = {}
+
+    bucket = config.get("bucket") or os.environ.get("AWS_S3_BUCKET")
+    if not bucket:
+        print("error: S3 bucket not specified. Add 'bucket:' to directive 'output' or set AWS_S3_BUCKET env var.", file=sys.stderr)
+        sys.exit(1)
+
+    prefix = config.get("prefix", os.environ.get("AWS_S3_PREFIX", "scrapes/"))
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+
+    key = f"{prefix}{name}.json"
+    
+    compact = config.get("compact", False)
+    indent = None if compact else 2
+    body_str = json.dumps(data, indent=indent, default=str)
+
+    try:
+        s3_client = boto3.client('s3')
+        s3_client.put_object(
+            Bucket=bucket,
+            Key=key,
+            Body=body_str,
+            ContentType='application/json'
+        )
+    except Exception as e:
+        print(f"error: failed to upload to S3: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    return f"s3://{bucket}/{key}"


### PR DESCRIPTION
## What does this PR do?
Adds support for AWS S3 as a storage destination via `--s3` flag or `output: backend: s3` configuration.

## Type of change
- [x] New feature

## How was this tested?
1. local help description check 
2. manual syntax-integrity checks on serialization dispatchers.

Fixes #144
